### PR TITLE
✨ Add new `/blog/tags/[tag]` pages.

### DIFF
--- a/src/components/blog/BlogSummaryCard.astro
+++ b/src/components/blog/BlogSummaryCard.astro
@@ -29,7 +29,9 @@ const { post } = Astro.props;
           post.data.tags.map((tag) => {
             return (
               <li>
-                <TagItem>{tag}</TagItem>
+                <a href={`/blog/tags/${tag.toLowerCase()}`}>
+                  <TagItem>{tag}</TagItem>
+                </a>
               </li>
             );
           })

--- a/src/content/blog/21-03-18-add-tailwind-jit-to-your-nuxtjs-site.md
+++ b/src/content/blog/21-03-18-add-tailwind-jit-to-your-nuxtjs-site.md
@@ -5,7 +5,7 @@ author: "Elian Van Cutsem"
 tags:
   - TailwindCSS
   - Nuxt
-  - '@tailwindcss/jit'
+  - JIT
 imgUrl: https://miro.medium.com/max/1400/1*oPL8C-i04sqAUoOS_da9aA.jpeg
 description: TailwindCSS just came out with a new feature called @tailwindcss/jit. here's how you can add it to your Nuxt site.
 layout: '../../layouts/BlogPost.astro'

--- a/src/content/blog/21-03-26-using-tailwindcss-with-sveltekit.md
+++ b/src/content/blog/21-03-26-using-tailwindcss-with-sveltekit.md
@@ -5,7 +5,7 @@ author: "Elian Van Cutsem"
 tags:
   - TailwindCSS
   - svelte
-  - '@tailwindcss/jit'
+  - JIT
 imgUrl: https://res.cloudinary.com/practicaldev/image/fetch/s--k-z0ysHD--/c_imagga_scale,f_auto,fl_progressive,h_420,q_auto,w_1000/https://dev-to-uploads.s3.amazonaws.com/uploads/articles/p3nn57r52krvpdieblta.png
 description: Earlier this week, Sveltekit beta got released, ofcourse I wanted to fiddle with it.
 layout: '../../layouts/BlogPost.astro'

--- a/src/content/blog/22-08-10-deploy-firebase-using-github-actions.md
+++ b/src/content/blog/22-08-10-deploy-firebase-using-github-actions.md
@@ -5,7 +5,7 @@ author: "Elian Van Cutsem"
 tags:
   - Firebase
   - Github actions
-  - CI/CD
+  - DevOps
 imgUrl: "https://firebase.google.com/images/social.png"
 description: Deploying to Firebase can sometimes be somewhat of a hassle if you're using the CLI. There is a better way using some sort of CI/CD, Github actions is one example explained here.
 layout: '../../layouts/BlogPost.astro'

--- a/src/content/blog/23-02-19-building-blog-tag-index-pages-in-astro.md
+++ b/src/content/blog/23-02-19-building-blog-tag-index-pages-in-astro.md
@@ -1,0 +1,147 @@
+---
+title: ✨ Building Blog tag index pages in Astro
+author: Elian Van Cutsem
+pubDate: 2023-02-19 18:37
+tags:
+  - Astro
+  - JavaScript
+  - Blog
+description: I wanted to add blog tag collection pages to my website. This way, people could filter on tags I used in my blog posts. Here is a guide on how I implemented it.
+imgUrl: https://i.imgur.com/Dpkd1vd.png
+layout: "../../layouts/BlogPost.astro"
+---
+
+# Building blog tag index pages in Astro
+
+When I was rebuilding my website with the 2023 redesign. I wanted to add blog tag collection pages as well. This way, people could 'filter' on tags I used in my blog posts. I wanted to do this in a way that was easy to maintain and didn't require me to write a lot of code. So I got hacking on it and found a very neat solution to do this. Here's a little guide on how I implemented it.
+
+## The goal
+
+The idea is to generate dynamic pages based on the tags put on the frontmatter of my blogposts. So that the user can search or filter on a tag and get a list of all related blogposts to that tag.
+
+The blogpost frontmatter validation:
+
+```js
+import { z, defineCollection } from "astro:content";
+
+const blogCollection = defineCollection({
+	schema: z.object({
+		title: z.string(),
+		author: z.string(),
+		tags: z.array(z.string()),
+		description: z.string(),
+		pubDate: z.string().transform((str) => new Date(str)),
+		imgUrl: z.string(),
+		draft: z.boolean().optional().default(false),
+	}),
+});
+```
+
+As you can see in the codeblock above, the tags are an array of strings. Which means one blogpost can contain multiple tags and one tag can have multiple blogposts.
+
+## Building the dynamic page
+
+Of course, tags are dynamic, so the first thing is to build a page with the `getStaticPaths()` method in Astro. In my case, that dynamic page is `/blog/tags/:tag`. The `getStaticPaths()` in Astro should always return a an object that looks like this:
+
+```js
+return {
+  params: { /* ... */ },
+  props: { /* ... */ },
+};
+```
+
+In my case, that means that the `params` object should return the tag string itself and the prop should return an array with all blogposts related to that tag.
+
+Let's start with getting all tags and build the static pages:
+
+```astro
+---
+import { getCollection } from 'astro:content';
+
+export async function getStaticPaths() {
+  const allPosts = await getCollection('blog');
+
+  const tags: string[] = [];
+
+  // using .toLowerCase() here to get rid of case sensitivity
+  allPosts.forEach((post) => {
+    post.data.tags.forEach((tag) => {
+      tags.push(tag.toLowerCase());
+    });
+  });
+
+  // using a new array from a set, we can get rid of duplicate tags 
+  return Array.from(new Set(tags)).map((tag) => {
+    return {
+      params: { tag },
+      // only keep the blogposts that contain the tag itself
+	  props: {
+	    blogposts: allPosts.filter((post) => post.data.tags.map(tag => tag.toLowerCase()).includes(tag)),
+	  }
+    };
+  });
+}
+---
+```
+
+Now, when we build the project, all of the tags get specific pages generated for them. with one prop called `blogposts`. I'm using the Astro v2.0 Content Collection API, but you can use `Astro.glob()` as well.
+
+## Adding the page layout and markup
+
+Now that are pages get generated, we want to display something when the user enters that page. We can define what the dynamic page should look like below the frontmatter.
+
+Also don't forget to add your `Astro.props` object for the page itself.
+
+```astro
+---
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+
+import Layout from '../../../layouts/YourLayout.astro';
+
+export async function getStaticPaths() {
+  const allPosts = await getCollection('blog');
+
+  const tags: string[] = [];
+
+  allPosts.forEach((post) => {
+    post.data.tags.forEach((tag) => {
+      tags.push(tag.toLowerCase());
+    });
+  });
+
+  return Array.from(new Set(tags)).map((tag) => {
+    return {
+      params: { tag },
+      props: {
+        blogposts: allPosts.filter((post) => post.data.tags.map(tag => tag.toLowerCase()).includes(tag)),
+      },
+    };
+  });
+}
+
+interface Props {
+  tag: string;
+  blogposts: CollectionEntry<'blog'>[];
+}
+
+const { blogposts } = Astro.props;
+---
+<Layout>
+  <main>
+	<ul>
+	  { blogposts.map(post => (
+	    <li>
+	      <a href={`/blog/${post.slug}`}>{post.data.title}</a>
+	    </li>
+	  ))}
+	</ul>
+  </main>
+</Layout>
+```
+
+This should now display your layout with a list of all blogposts related to the tag!
+
+Keep in mind you should still customize this page to fit your needs, otherwise it's kinda ugly.
+
+If you're interested on how I implemented this on [my own website](<https://www.elian.codes>), you can always take a peek into [the source code](<https://www.github.com/eliancodes/eliancodes-frontend>).

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 
 export async function getStaticPaths() {
   const blogEntries = await getCollection('blog');
@@ -7,6 +8,10 @@ export async function getStaticPaths() {
     params: { slug: blogpost.slug },
     props: { blogpost },
   }));
+}
+
+interface Props {
+  blogpost: CollectionEntry<'blog'>;
 }
 
 const { blogpost } = Astro.props;

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 import Layout from '../../../layouts/Default.astro';
 import BlogList from '../../../components/blog/BlogList.astro';
 import Button from '../../../components/generic/Button.astro';
@@ -24,6 +25,11 @@ export async function getStaticPaths() {
       },
     };
   });
+}
+
+interface Props {
+  tag: string;
+  blogposts: CollectionEntry<'blog'>[];
 }
 
 const { tag, blogposts } = Astro.props;

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,0 +1,42 @@
+---
+import { getCollection } from 'astro:content';
+import Layout from '../../../layouts/Default.astro';
+import BlogList from '../../../components/blog/BlogList.astro';
+import Button from '../../../components/generic/Button.astro';
+
+export async function getStaticPaths() {
+  const allPosts = await getCollection('blog');
+
+  const tags: string[] = []
+  
+  allPosts.forEach((post) => {
+    post.data.tags.forEach((tag) => {
+      tags.push(tag);
+    });
+  });
+
+  const tagSet = Array.from(new Set(tags));
+
+  console.log(tagSet);
+
+  return tagSet.map((tag) => {
+    return {
+      params: { tag: tag.toLowerCase() },
+      props: { tag: tag, blogposts: allPosts.filter((post) => post.data.tags.includes(tag)) }
+    }
+  });
+}
+
+const { tag } = Astro.props;
+---
+<Layout
+  title={`Blog: ${tag}`}
+  description={`All posts tagged with ${tag}`}
+>
+  <main class="p-6 bg-purple grid gap-4">
+    <div>
+      <Button href="/blog">&larr; Back to blog</Button>
+    </div>
+    <BlogList posts={Astro.props.blogposts} />
+  </main>
+</Layout>

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -5,38 +5,35 @@ import BlogList from '../../../components/blog/BlogList.astro';
 import Button from '../../../components/generic/Button.astro';
 
 export async function getStaticPaths() {
-  const allPosts = await getCollection('blog');
+  const allPosts = await getCollection('blog').then((collection) => collection.reverse());
 
-  const tags: string[] = []
-  
+  const tags: string[] = [];
+
   allPosts.forEach((post) => {
     post.data.tags.forEach((tag) => {
-      tags.push(tag);
+      tags.push(tag.toLowerCase());
     });
   });
 
-  const tagSet = Array.from(new Set(tags));
-
-  console.log(tagSet);
-
-  return tagSet.map((tag) => {
+  return Array.from(new Set(tags)).map((tag) => {
     return {
-      params: { tag: tag.toLowerCase() },
-      props: { tag: tag, blogposts: allPosts.filter((post) => post.data.tags.includes(tag)) }
-    }
+      params: { tag },
+      props: {
+        tag,
+        blogposts: allPosts.filter((post) => post.data.tags.map(tag => tag.toLowerCase()).includes(tag)),
+      },
+    };
   });
 }
 
-const { tag } = Astro.props;
+const { tag, blogposts } = Astro.props;
 ---
-<Layout
-  title={`Blog: ${tag}`}
-  description={`All posts tagged with ${tag}`}
->
-  <main class="p-6 bg-purple grid gap-4">
+
+<Layout title={`Blog: ${tag}`} description={`All posts tagged with ${tag}`}>
+  <main class='p-6 bg-purple grid gap-4'>
     <div>
-      <Button href="/blog">&larr; Back to blog</Button>
+      <Button href='/blog'>&larr; Back to blog</Button>
     </div>
-    <BlogList posts={Astro.props.blogposts} />
+    <BlogList posts={blogposts} />
   </main>
 </Layout>


### PR DESCRIPTION
## Feature

Autogenerates pages with all blogposts related to a tag. Tag pages themselves, get generated by `getStaticPaths()`

## Todo

- [x] Add blogpost about it as well

## Closes

closes #323 