### PR TITLE
upgrade astro-font to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"@resvg/resvg-js": "^2.6.0",
 		"@unocss/astro": "^0.57.2",
 		"astro": "^4.0.2",
-		"astro-font": "^0.0.68",
+		"astro-font": "^0.0.72",
 		"unocss": "^0.57.2"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: ^4.0.2
     version: 4.0.2(typescript@5.2.2)
   astro-font:
-    specifier: ^0.0.68
-    version: 0.0.68
+    specifier: ^0.0.72
+    version: 0.0.72
   unocss:
     specifier: ^0.57.2
     version: 0.57.2(postcss@8.4.32)(vite@4.5.0)
@@ -1270,19 +1270,6 @@ packages:
       string.prototype.codepointat: 0.2.1
     dev: true
 
-  /@swc/helpers@0.4.14:
-    resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@swc/helpers@0.4.36:
-    resolution: {integrity: sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==}
-    dependencies:
-      legacy-swc-helpers: /@swc/helpers@0.4.14
-      tslib: 2.6.2
-    dev: false
-
   /@types/babel__core@7.20.5:
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
     dependencies:
@@ -1938,11 +1925,8 @@ packages:
       - supports-color
     dev: true
 
-  /astro-font@0.0.68:
-    resolution: {integrity: sha512-CcBwDRHMqHp1hGgCHYltmtVUOcClWhABIY1C3qEuLDtBa0vFP9/GAi0sj/b9fjh5Y2ZhRKcMd0scM/ZYqo0Kug==}
-    dependencies:
-      fontkit: 2.0.2
-      github-slugger: 2.0.0
+  /astro-font@0.0.72:
+    resolution: {integrity: sha512-FUjIerovSg2lsfJfvvqY23hgvc++gHi69ikFkxm0mqO3MPFykK5ppeUuROUjhNbE6vwdD8MpiJOy1CR5S0g/lQ==}
     dev: false
 
   /astro@4.0.2(typescript@5.2.2):
@@ -2154,12 +2138,6 @@ packages:
     dependencies:
       fill-range: 7.0.1
 
-  /brotli@1.3.3:
-    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
-    dependencies:
-      base64-js: 1.5.1
-    dev: false
-
   /browserslist@4.22.1:
     resolution: {integrity: sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -2326,11 +2304,6 @@ packages:
   /cli-spinners@2.9.1:
     resolution: {integrity: sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==}
     engines: {node: '>=6'}
-    dev: false
-
-  /clone@2.1.2:
-    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
-    engines: {node: '>=0.8'}
     dev: false
 
   /clsx@2.0.0:
@@ -2597,10 +2570,6 @@ packages:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
     dependencies:
       dequal: 2.0.3
-    dev: false
-
-  /dfa@1.2.0:
-    resolution: {integrity: sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==}
     dev: false
 
   /diff@5.1.0:
@@ -3161,6 +3130,7 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: true
 
   /fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
@@ -3268,20 +3238,6 @@ packages:
   /flattie@1.1.0:
     resolution: {integrity: sha512-xU99gDEnciIwJdGcBmNHnzTJ/w5AT+VFJOu6sTB6WM8diOYNA3Sa+K1DiEBQ7XH4QikQq3iFW1U+jRVcotQnBw==}
     engines: {node: '>=8'}
-    dev: false
-
-  /fontkit@2.0.2:
-    resolution: {integrity: sha512-jc4k5Yr8iov8QfS6u8w2CnHWVmbOGtdBtOXMze5Y+QD966Rx6PEVWXSEGwXlsDlKtu1G12cJjcsybnqhSk/+LA==}
-    dependencies:
-      '@swc/helpers': 0.4.36
-      brotli: 1.3.3
-      clone: 2.1.2
-      dfa: 1.2.0
-      fast-deep-equal: 3.1.3
-      restructure: 3.0.0
-      tiny-inflate: 1.0.3
-      unicode-properties: 1.4.1
-      unicode-trie: 2.0.0
     dev: false
 
   /for-each@0.3.3:
@@ -4996,6 +4952,7 @@ packages:
 
   /pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+    dev: true
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -5409,10 +5366,6 @@ packages:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
-    dev: false
-
-  /restructure@3.0.0:
-    resolution: {integrity: sha512-Xj8/MEIhhfj9X2rmD9iJ4Gga9EFqVlpMj3vfLnV2r/Mh5jRMryNV+6lWh9GdJtDBcBSPIqzRdfBQ3wDtNFv/uw==}
     dev: false
 
   /retext-latin@3.1.0:
@@ -5973,6 +5926,7 @@ packages:
 
   /tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+    dev: true
 
   /titleize@3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
@@ -6035,6 +5989,7 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+    dev: true
 
   /tsutils@3.21.0(typescript@5.2.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -6144,18 +6099,12 @@ packages:
     resolution: {integrity: sha512-akOOQ/Yln8a2sgcLj4U0Jmx0R5jpIg2IUyRrWOzmEbjBtGzBdHtSeFKgoEcoH4KYIG/Pb8GQ/BwtYm0GCq1Sqg==}
     dev: false
 
-  /unicode-properties@1.4.1:
-    resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
-    dependencies:
-      base64-js: 1.5.1
-      unicode-trie: 2.0.0
-    dev: false
-
   /unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
     dependencies:
       pako: 0.2.9
       tiny-inflate: 1.0.3
+    dev: true
 
   /unified@10.1.2:
     resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}

--- a/src/components/layout/LocalFont.astro
+++ b/src/components/layout/LocalFont.astro
@@ -1,72 +1,76 @@
 ---
+import { join } from "node:path";
 import { AstroFont } from "astro-font";
+
+const appDir = process.cwd();
+const getFontPath = (name: string) => join(appDir, "public", "fonts", name);
 ---
 
 <AstroFont
-	config={[
-		{
-			name: "Outfit",
-			display: "swap",
-			selector: ".outfit",
-			fallback: "sans-serif",
-			src: [
-				{
-					style: "normal",
-					path: "./public/fonts/outfit.ttf",
-				},
-			],
-		},
-		{
-			display: "swap",
-			name: "Poppins",
-			selector: ".poppins",
-			fallback: "sans-serif",
-			src: [
-				{
-					preload: false,
-					style: "normal",
-					path: "./public/fonts/poppins.ttf",
-				},
-			],
-		},
-		{
-			display: "swap",
-			name: "Righteous",
-			fallback: "sans-serif",
-			selector: ".righteous",
-			src: [
-				{
-					preload: false,
-					style: "normal",
-					path: "./public/fonts/righteous.ttf",
-				},
-			],
-		},
-		{
-			display: "swap",
-			name: "Sanchez",
-			fallback: "serif",
-			selector: ".sanchez",
-			src: [
-				{
-					preload: false,
-					style: "normal",
-					path: "./public/fonts/sanchez.ttf",
-				},
-			],
-		},
-		{
-			display: "swap",
-			fallback: "serif",
-			selector: ".dm-serif",
-			name: "DM Serif Text",
-			src: [
-				{
-					preload: false,
-					style: "normal",
-					path: "./public/fonts/dm-serif.ttf",
-				},
-			],
-		},
-	]}
+  config={[
+    {
+      name: "Outfit",
+      display: "swap",
+      selector: ".outfit",
+      fallback: "sans-serif",
+      src: [
+        {
+          style: "normal",
+          path: getFontPath("outfit.ttf"),
+        },
+      ],
+    },
+    {
+      display: "swap",
+      name: "Poppins",
+      selector: ".poppins",
+      fallback: "sans-serif",
+      src: [
+        {
+          preload: false,
+          style: "normal",
+          path: getFontPath("poppins.ttf"),
+        },
+      ],
+    },
+    {
+      display: "swap",
+      name: "Righteous",
+      fallback: "sans-serif",
+      selector: ".righteous",
+      src: [
+        {
+          preload: false,
+          style: "normal",
+          path: getFontPath("righteous.ttf"),
+        },
+      ],
+    },
+    {
+      display: "swap",
+      name: "Sanchez",
+      fallback: "serif",
+      selector: ".sanchez",
+      src: [
+        {
+          preload: false,
+          style: "normal",
+          path: getFontPath("sanchez.ttf"),
+        },
+      ],
+    },
+    {
+      display: "swap",
+      fallback: "serif",
+      selector: ".dm-serif",
+      name: "DM Serif Text",
+      src: [
+        {
+          preload: false,
+          style: "normal",
+          path: getFontPath("dm-serif.ttf"),
+        },
+      ],
+    },
+  ]}
 />


### PR DESCRIPTION
- upgrades `astro-font` to latest
- uses node specific delimiter to support all OS