### PR TITLE
Suggested fix: blog post tags wrapping.

### DIFF
--- a/src/components/blog/BlogSummaryCard.astro
+++ b/src/components/blog/BlogSummaryCard.astro
@@ -23,7 +23,7 @@ const { post } = Astro.props;
 	<div class="hidden sm:inline-block">
 		<p class="poppins mt-2">tags:</p>
 		<div class="flex justify-between items-center">
-			<ul class="flex gap-4 mt-2">
+			<ul class="flex gap-4 mt-2 flex-wrap">
 				{
 					post.data.tags.map((tag) => {
 						return (


### PR DESCRIPTION
Hi @ElianCodes

Hope you've been well!

I was reading through your posts and noticed that some tags are not wrapping properly.

**Changes**

- Fixed the wrapping of the blog post tags.

**Before**

![image](https://github.com/ElianCodes/ElianCodes-frontend/assets/54312759/f719a9c7-67ff-4b9e-88cb-51f4f5cde198)
![image](https://github.com/ElianCodes/ElianCodes-frontend/assets/54312759/73b08682-f92a-461e-aa04-3deb7100e838)

**After**
![image](https://github.com/ElianCodes/ElianCodes-frontend/assets/54312759/151bf5e6-c9e4-4a47-b864-7421041c8fe5)
![image](https://github.com/ElianCodes/ElianCodes-frontend/assets/54312759/a2c2008a-76c9-4e5f-b7fc-ad343e22988a)


