### PR TITLE
fix(seo): consolidate Person entity with shared @id

### DIFF
--- a/src/components/layout/BaseHead.astro
+++ b/src/components/layout/BaseHead.astro
@@ -40,6 +40,8 @@ const fullTitle = title === "Elian Codes" ? title : `Elian Codes | ${title}`;
 const imageAlt = socialImgAlt ?? `${fullTitle} social preview image`;
 const schemaList = Array.isArray(schema) ? schema : schema ? [schema] : [];
 
+const personId = `${siteUrl.toString()}#person`;
+
 const siteSchema = {
 	"@context": "https://schema.org",
 	"@type": "WebSite",
@@ -49,12 +51,14 @@ const siteSchema = {
 	inLanguage: "en",
 	publisher: {
 		"@type": "Person",
+		"@id": personId,
 		name: "Elian Van Cutsem",
 		url: siteUrl.toString(),
 		sameAs: [
-			"https://github.com/eliancodes",
-			"https://www.linkedin.com/in/elianvancutsem/",
+			"https://github.com/ElianCodes",
+			"https://www.linkedin.com/in/elianvancutsem",
 			"https://x.com/eliancodes",
+			"https://eliancodes.com",
 		],
 	},
 };

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -11,6 +11,10 @@ const blogCollection = defineCollection({
 			tags: z.array(z.string()),
 			description: z.string(),
 			pubDate: z.string().transform((str) => new Date(str)),
+			updatedDate: z
+				.string()
+				.transform((str) => new Date(str))
+				.optional(),
 			imgUrl: image(),
 			draft: z.boolean().optional().default(false),
 		}),

--- a/src/layouts/new/Blogpost.astro
+++ b/src/layouts/new/Blogpost.astro
@@ -24,23 +24,16 @@ const {
 	socialImgHeight,
 } = Astro.props;
 const articleUrl = new URL(Astro.url.pathname, Astro.site).toString();
+const personId = `${new URL("/", Astro.site).toString()}#person`;
 const articleSchema = {
 	"@context": "https://schema.org",
 	"@type": "BlogPosting",
 	headline: post.title,
 	description: post.description,
 	datePublished: post.pubDate.toISOString(),
-	dateModified: post.pubDate.toISOString(),
-	author: {
-		"@type": "Person",
-		name: post.author,
-		url: new URL("/", Astro.site).toString(),
-	},
-	publisher: {
-		"@type": "Person",
-		name: "Elian Van Cutsem",
-		url: new URL("/", Astro.site).toString(),
-	},
+	dateModified: (post.updatedDate ?? post.pubDate).toISOString(),
+	author: { "@id": personId },
+	publisher: { "@id": personId },
 	mainEntityOfPage: articleUrl,
 	url: articleUrl,
 	image: socialImg?.toString(),

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,6 +19,7 @@ const homeSchema = [
 		url: new URL("/", Astro.site).toString(),
 		mainEntity: {
 			"@type": "Person",
+			"@id": `${new URL("/", Astro.site).toString()}#person`,
 			name: "Elian Van Cutsem",
 			url: new URL("/", Astro.site).toString(),
 			jobTitle: "CTO, DevRel leader, and public speaker",
@@ -26,9 +27,10 @@ const homeSchema = [
 			description:
 				"Belgian web developer and consultant focused on developer experience, Astro, React, web engineering, and community building.",
 			sameAs: [
-				"https://github.com/eliancodes",
-				"https://www.linkedin.com/in/elianvancutsem/",
+				"https://github.com/ElianCodes",
+				"https://www.linkedin.com/in/elianvancutsem",
 				"https://x.com/eliancodes",
+				"https://eliancodes.com",
 			],
 		},
 	},
@@ -38,19 +40,19 @@ const homeSchema = [
 		name: "Main sections",
 		itemListElement: [
 			{
-				"@type": "ListItem",
+				"@type": "SiteNavigationElement",
 				position: 1,
 				name: "About",
 				url: new URL("/", Astro.site).toString(),
 			},
 			{
-				"@type": "ListItem",
+				"@type": "SiteNavigationElement",
 				position: 2,
 				name: "Blog",
 				url: new URL("/blog/", Astro.site).toString(),
 			},
 			{
-				"@type": "ListItem",
+				"@type": "SiteNavigationElement",
 				position: 3,
 				name: "Events",
 				url: new URL("/events/", Astro.site).toString(),


### PR DESCRIPTION
## Summary
Consolidates the Person into a single entity across the whole site and cleans up nav + blog structured data.

**Homepage / global (`BaseHead.astro`, `index.astro`)**
- Shared Person `@id` (`https://www.elian.codes/#person`) on both the WebSite `publisher` and the `ProfilePage` `mainEntity`, so search engines see one person, not two.
- `sameAs` normalized to byte-identical forms (`github.com/ElianCodes`, `linkedin.com/in/elianvancutsem` without trailing slash) matching eliancodes.com.
- Added `https://eliancodes.com` to `sameAs` for bidirectional cross-domain entity linking.
- Nav `ItemList` now uses `SiteNavigationElement`.

**Blog (`Blogpost.astro`, `content.config.ts`)**
- `BlogPosting` `author` and `publisher` now reference the shared Person `@id` instead of inline anonymous Person nodes, so every post links to the same entity rather than spawning duplicate Persons.
- Added optional `updatedDate` to the blog content schema and wired it to `dateModified`, so edited posts report an accurate modified date (falls back to `pubDate`).

## Test plan
- [ ] `pnpm build` (runs `astro check`) passes
- [ ] Confirm a blog post emits one `BlogPosting` with `author`/`publisher` `@id` resolving to the Person node from BaseHead
- [ ] Run homepage + a blog post through Google Rich Results Test / validator.schema.org