### PR TITLE
fix(home): real sponsor descriptions + alt text

### DIFF
--- a/src/components/home/SponsorList.astro
+++ b/src/components/home/SponsorList.astro
@@ -17,35 +17,35 @@ const sponsoring: Sponsor[] = [
 		name: "Biome",
 		avatar: "https://avatars.githubusercontent.com/u/140182603?s=200&v=4",
 		link: "https://github.com/biomejs",
-		description: "Why it's awesome",
+		description: "a fast formatter and linter for the web.",
 		since: new Date("2024-01-01"),
 	},
 	{
 		name: "Vite",
 		avatar: "https://avatars.githubusercontent.com/u/65625612?s=200&v=4",
 		link: "https://github.com/vitejs",
-		description: "Why it's awesome",
+		description: "the build tool that powers the modern web.",
 		since: new Date("2024-01-01"),
 	},
 	{
 		name: "Evan You",
 		avatar: "https://avatars.githubusercontent.com/u/499550?v=4",
 		link: "https://github.com/yyx990803",
-		description: "Why it's awesome",
+		description: "the creator of Vue and Vite.",
 		since: new Date("2024-01-01"),
 	},
 	{
 		name: "Josh Goldberg",
 		avatar: "https://avatars.githubusercontent.com/u/3335181?v=4",
 		link: "https://github.com/JoshuaKGoldberg",
-		description: "Why it's awesome",
+		description: "a full-time open-source maintainer of typescript-eslint.",
 		since: new Date("2024-01-01"),
 	},
 	{
 		name: "Anthony Fu",
 		avatar: "https://avatars.githubusercontent.com/u/11247099?v=4",
 		link: "https://github.com/antfu",
-		description: "Why it's awesome",
+		description: "the creator of Vitest, UnoCSS, and Slidev.",
 		since: new Date("2024-01-01"),
 	},
 ].sort((left, right) => right.since.getTime() - left.since.getTime());
@@ -57,12 +57,13 @@ const sponsoring: Sponsor[] = [
 			<ProjectCard
 				link={sponsor.link}
 				image={sponsor.avatar}
+				imageAlt={`${sponsor.name} avatar`}
 				title={sponsor.name}
-				description={`Sponsored from ${format(sponsor.since, "MMMM yyyy")} ${
+				description={`Sponsored since ${format(sponsor.since, "MMMM yyyy")}${
 					sponsor.ended_at
-						? `until ${format(sponsor.ended_at, "MMMM yyyy")}`
+						? ` until ${format(sponsor.ended_at, "MMMM yyyy")}`
 						: ""
-				} because ${sponsor.description}`}
+				} — ${sponsor.description}`}
 			/>
 		</ListItem>
 	))


### PR DESCRIPTION
Fixes two homepage issues found during the SEO/content audit.

## Problems
1. **Placeholder copy in production** — every sponsor used the description `"Why it's awesome"`, so the homepage rendered *"Sponsored from January 2024  because Why it's awesome"* (×5), including a stray double space.
2. **Empty `alt` on sponsor logos** — `SponsorList` never passed `imageAlt`, and `ProjectCard` defaults to `alt=""`, so all 5 sponsor avatars were invisible to screen readers and image search.

## Changes
- Accurate one-line descriptions for each sponsor (Biome, Vite, Evan You, Josh Goldberg, Anthony Fu) — all factual, public info.
- Pass `imageAlt={`${sponsor.name} avatar`}` to `ProjectCard`.
- Tidy the sentence template: `Sponsored since January 2024 — <description>` (no double space, no dangling "because").

## Verification
- `astro check` passes (0 errors / 0 warnings / 0 hints).

> Wording is my best factual guess — tweak the descriptions to your voice if you'd like.