### PR TITLE
feat(footer): link to ElianCodes agency from the bio

### DIFF
--- a/src/components/ui/layout/BaseFooter.astro
+++ b/src/components/ui/layout/BaseFooter.astro
@@ -27,7 +27,11 @@ const { links, ...rest } = Astro.props;
 					href='https://reactbricks.com'
 					class='underline'
 					target='_blank'>React Bricks</LinkPrimary
-				>. My love for the web was first sparked in 2018 when I decided to build
+				>. I also run
+				<LinkPrimary href='https://eliancodes.com' class='underline'
+					>ElianCodes</LinkPrimary
+				>, my Laravel & Astro development agency. My love for the web was first
+				sparked in 2018 when I decided to build
 				a simple HTML page to display the photos I took at the time, there was
 				no way back! Since then and there, I was completely in love with
 				building on and for the web. I transitioned to a Wordpress drag-and-drop


### PR DESCRIPTION
Adds a site-wide contextual link from elian.codes → eliancodes.com to pass referral traffic and link equity to the agency site.

## Why
From GSC: elian.codes pulls real organic traffic (~388 clicks/3mo, mostly dev tutorials) while eliancodes.com is near-invisible (3 clicks/3mo). The personal site already references the agency in structured data (`sameAs`), but there was **no visible, crawlable link** between them. A descriptive-anchor link in the footer — which renders on all ~107 indexed pages, including the high-traffic blog posts — gives Google a real signal and sends interested readers to the agency.

## Change
- One sentence added to the footer bio (next to Vulpo and React Bricks):
  *"I also run **ElianCodes**, my Laravel & Astro development agency."*
- Anchor text is descriptive ("ElianCodes" + "Laravel & Astro development agency") rather than a bare URL, and it's a normal followed link.

## Verification
- `astro check` passes (0 errors / 0 warnings / 0 hints).