### PR TITLE
feat(seo): enrich Person schema with knowsAbout, worksFor, and location

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,6 +26,42 @@ const homeSchema = [
 			image: homeImage,
 			description:
 				"Belgian web developer and consultant focused on developer experience, Astro, React, web engineering, and community building.",
+			knowsAbout: [
+				"Astro",
+				"React",
+				"Developer Relations",
+				"Web Performance",
+				"TypeScript",
+				"JavaScript",
+				"Deno",
+				"Developer Experience",
+				"Web Development",
+			],
+			worksFor: [
+				{
+					"@type": "Organization",
+					name: "Vulpo",
+					url: "https://vulpo.be",
+				},
+				{
+					"@type": "Organization",
+					name: "React Bricks",
+					url: "https://reactbricks.com",
+				},
+			],
+			homeLocation: {
+				"@type": "Place",
+				address: {
+					"@type": "PostalAddress",
+					addressLocality: "Ghent",
+					addressRegion: "East Flanders",
+					addressCountry: "BE",
+				},
+			},
+			nationality: {
+				"@type": "Country",
+				name: "Belgium",
+			},
 			sameAs: [
 				"https://github.com/ElianCodes",
 				"https://www.linkedin.com/in/elianvancutsem",


### PR DESCRIPTION
## Summary
Enriches the home `ProfilePage` mainEntity Person (`#person`) JSON-LD with structured signals that help search and generative engines (GEO) understand who Elian is.

- `knowsAbout`: Astro, React, Developer Relations, web performance, TypeScript, JavaScript, Deno, DX, web development
- `worksFor`: Vulpo (https://vulpo.be) + React Bricks (https://reactbricks.com)
- `homeLocation`: Ghent, East Flanders, BE (geo signal)
- `nationality`: Belgium

The node keeps its existing `@id` (`https://www.elian.codes/#person`) so it stays consolidated with the publisher node in BaseHead and the per-post BlogPosting `author`/`publisher` references. No changes to the lean publisher reference node.

## Test plan
- [x] `astro check` — 0 errors
- [x] `astro build` — site builds
- [ ] Validate rich result via Google Rich Results Test / Schema validator after deploy