### PR TITLE
feat(analytics): add production-gated GA4 to elian.codes

### DIFF
--- a/src/components/layout/BaseHead.astro
+++ b/src/components/layout/BaseHead.astro
@@ -42,6 +42,10 @@ const schemaList = Array.isArray(schema) ? schema : schema ? [schema] : [];
 
 const personId = `${siteUrl.toString()}#person`;
 
+// Only load GA on the production domain — not on preview deploys or local builds.
+const gaId = "G-13MBMB5GZJ";
+const analyticsEnabled = process.env.VERCEL_ENV === "production";
+
 const siteSchema = {
 	"@context": "https://schema.org",
 	"@type": "WebSite",
@@ -68,6 +72,27 @@ const siteSchema = {
 	<meta charset='utf-8' />
 	<meta name='viewport' content='width=device-width, initial-scale=1' />
 	<meta name='generator' content={Astro.generator} />
+
+	{
+		analyticsEnabled && (
+			<Fragment>
+				<script
+					is:inline
+					async
+					src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+				/>
+				<script is:inline define:vars={{ gaId }}>
+					window.dataLayer = window.dataLayer || [];
+					function gtag() {
+						dataLayer.push(arguments);
+					}
+					gtag("js", new Date());
+					gtag("config", gaId);
+				</script>
+			</Fragment>
+		)
+	}
+
 	<LocalFont />
 
 	<link


### PR DESCRIPTION
## Summary
Adds Google Analytics 4 (gtag.js) to the personal site — it previously had **no analytics at all**. Uses a dedicated property (`G-13MBMB5GZJ`), separate from the agency's.

- Injected in the shared `BaseHead.astro` so it loads on every page
- **Gated on `process.env.VERCEL_ENV === "production"`** (same condition `astro.config.ts` uses for `site`), so preview deploys and local builds do **not** send hits
- Mirrors the agency site's production-gated gtag pattern

## Test plan
- [x] `astro check` — 0 errors / 0 warnings / 0 hints
- [x] Prod build (`VERCEL_ENV=production`) → gtag present on `/` and `/blog/`
- [x] Default build → gtag absent (0 occurrences)
- [ ] After deploy: confirm Realtime hits in GA4 for `G-13MBMB5GZJ`